### PR TITLE
Update CI build and push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v4
         with:
+          provenance: false
           context: ./images/
           push: true
           tags: ${{ steps.image-meta.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         id: image-meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/stackhpc/io500-singularity
+          images: ghcr.io/${{ github.repository }}
           # Produce the branch name or tag and the SHA as tags
           tags: |
             type=ref,event=branch


### PR DESCRIPTION
According to this bug report: https://github.com/docker/build-push-action/issues/771, the build-push action builds images with provenance data, which breaks GHCR (https://github.com/docker/buildx/issues/1533).

Set `provenance: false` to make this not happen.

Adding this restores the ability to pull built images from GHCR.